### PR TITLE
Makefile: install library into correct directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,18 +7,28 @@ SRC = $(wildcard */*.c) filter_audio.c
 OBJ = $(SRC:.c=.o)
 HEADER = filter_audio.h
 
+# Check on which platform we are running
+UNAME_M = $(shell uname -m)
+ifeq ($(UNAME_M), x86_64)
+	LIBDIR = lib64
+else
+	LIBDIR = lib
+endif
+
 all: $(TARGET)
 
 $(TARGET): $(OBJ)
-	$(CC) $(LDFLAGS) $(LDLIBS) -shared -o $@ $^
+	@echo "  LD    $@"
+	@$(CC) $(LDFLAGS) $(LDLIBS) -shared -o $@ $^
 
 %.o: %.c
-	$(CC) $(CFLAGS) -fPIC -c -o $@ $<
+	@echo "  CC    $@"
+	@$(CC) $(CFLAGS) -fPIC -c -o $@ $<
 
 install: all $(HEADER)
-	mkdir -p $(DESTDIR)/$(PREFIX)/lib
+	mkdir -p $(DESTDIR)/$(PREFIX)/$(LIBDIR)
 	mkdir -p $(DESTDIR)/$(PREFIX)/include
-	install -m755 $(TARGET) $(DESTDIR)/$(PREFIX)/lib/$(TARGET)
+	install -m755 $(TARGET) $(DESTDIR)/$(PREFIX)/$(LIBDIR)/$(TARGET)
 	install -m644 $(HEADER) $(DESTDIR)/$(PREFIX)/include/$(HEADER)
 
 clean:


### PR DESCRIPTION
On x86_64 the library should be installed into `$(PREFIX)/lib64`.