### PR TITLE
Makefile: revert back to "lib" directory and add "INCLUDEDIR"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 BASE_NAME = libfilteraudio
 VERSION = 0.0.0
 PREFIX ?= /usr/local
+LIBDIR ?= lib
+INCLUDEDIR ?= include
 
 TARGET = $(BASE_NAME).so.$(VERSION)
 SHARED_LIB = $(BASE_NAME).so.$(shell echo $(VERSION) | rev | cut -d "." -f 1 | rev)
@@ -11,14 +13,6 @@ SRC = $(wildcard */*.c) filter_audio.c
 OBJ = $(SRC:.c=.o)
 HEADER = filter_audio.h
 LDFLAGS += -lm -lpthread -Wl,-soname=$(SHARED_LIB)
-
-# Check on which platform we are running
-UNAME_M = $(shell uname -m)
-ifeq ($(UNAME_M), x86_64)
-	LIBDIR = lib64
-else
-	LIBDIR = lib
-endif
 
 all: $(TARGET)
 
@@ -36,15 +30,16 @@ $(TARGET): $(OBJ)
 
 install: all $(HEADER) $(PC_FILE)
 	mkdir -p $(abspath $(DESTDIR)/$(PREFIX)/$(LIBDIR)/pkgconfig)
-	mkdir -p $(abspath $(DESTDIR)/$(PREFIX)/include)
+	mkdir -p $(abspath $(DESTDIR)/$(PREFIX)/$(INCLUDEDIR))
 	@echo "Installing $(TARGET)"
 	@install -m755 $(TARGET) $(abspath $(DESTDIR)/$(PREFIX)/$(LIBDIR)/$(TARGET))
 	@echo "Installing $(HEADER)"
-	@install -m644 $(HEADER) $(abspath $(DESTDIR)/$(PREFIX)/include/$(HEADER))
+	@install -m644 $(HEADER) $(abspath $(DESTDIR)/$(PREFIX)/$(INCLUDEDIR)/$(HEADER))
 	@echo "Installing $(PC_FILE)"
 	@install -m644 $(PC_FILE) $(abspath $(DESTDIR)/$(PREFIX)/$(LIBDIR)/pkgconfig/$(PC_FILE))
 	@sed -i'' -e 's:__PREFIX__:'$(abspath $(PREFIX))':g' $(abspath $(DESTDIR)/$(PREFIX)/$(LIBDIR)/pkgconfig/$(PC_FILE))
 	@sed -i'' -e 's:__LIBDIR__:'$(abspath $(PREFIX)/$(LIBDIR))':g' $(abspath $(DESTDIR)/$(PREFIX)/$(LIBDIR)/pkgconfig/$(PC_FILE))
+	@sed -i'' -e 's:__INCLUDEDIR__:'$(abspath $(PREFIX)/$(INCLUDEDIR))':g' $(abspath $(DESTDIR)/$(PREFIX)/$(LIBDIR)/pkgconfig/$(PC_FILE))
 	@sed -i'' -e 's:__VERSION__:'$(VERSION)':g' $(abspath $(DESTDIR)/$(PREFIX)/$(LIBDIR)/pkgconfig/$(PC_FILE))
 	@cd $(abspath $(DESTDIR)/$(PREFIX)/$(LIBDIR)) ; ln -sf $(TARGET) $(SHARED_LIB) ; ln -sf $(SHARED_LIB) $(BASE_NAME).so
 	@if [ "$(NO_STATIC)" != "1" ]; then \

--- a/filteraudio.pc
+++ b/filteraudio.pc
@@ -1,6 +1,6 @@
 prefix=__PREFIX__
 libdir=__LIBDIR__
-includedir=${prefix}/include
+includedir=__INCLUDEDIR__
 
 Name: filteraudio
 Description: Lightweight audio filtering library made from webrtc code


### PR DESCRIPTION
People can specify a different location for library installation
using `make install LIBDIR="lib_dir"` and a different location for
headers with `make install INCLUDEDIR="include_dir"`.
Example for debian x86:
```
make install LIBDIR="lib/i386-linux-gnu" INCLUDEDIR="include/i386-linux-gnu"
```
This should make @dubslow happy.