### PR TITLE
Fixed twice assigned values

### DIFF
--- a/aec/aec_core.c
+++ b/aec/aec_core.c
@@ -675,7 +675,6 @@ static void UpdateMetrics(AecCore* aec) {
       dtmp = 10 * (float)log10(aec->farlevel.averagelevel /
                                    aec->nearlevel.averagelevel +
                                1e-10f);
-      dtmp2 = 10 * (float)log10(aec->farlevel.averagelevel / echo + 1e-10f);
 
       aec->erl.instant = dtmp;
       if (dtmp > aec->erl.max) {
@@ -734,12 +733,8 @@ static void UpdateMetrics(AecCore* aec) {
       suppressedEcho = 2 * (aec->nlpoutlevel.averagelevel -
                             safety * aec->nlpoutlevel.minlevel);
 
-      dtmp = 10 * (float)log10(aec->nearlevel.averagelevel /
-                                   (2 * aec->nlpoutlevel.averagelevel) +
-                               1e-10f);
-      dtmp2 = 10 * (float)log10(echo / suppressedEcho + 1e-10f);
+      dtmp = 10 * (float)log10(echo / suppressedEcho + 1e-10f);
 
-      dtmp = dtmp2;
       aec->erle.instant = dtmp;
       if (dtmp > aec->erle.max) {
         aec->erle.max = dtmp;


### PR DESCRIPTION
I like your project and I'm exploring it as part of the competition the Pinguem.ru competition on finding errors in open source projects. New warnings, found using PVS-Studio:
filter_audio/aec/aec_core.c	709	warn	V519 The 'dtmp2' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 678, 709.
filter_audio/aec/aec_core.c	742	warn	V519 The 'dtmp' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 737, 742.

If it was misprint or i made a mistake, just tell me.