### PR TITLE
Pass -dead_strip -bind_at_load on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ ifeq ($(UNAME_S), Darwin)
     TARGET = $(BASE_NAME).$(VERSION).$(SHARED_EXT)
     SHARED_LIB = $(BASE_NAME).$(shell echo $(VERSION) | rev | cut -d "." -f 1 | rev).$(SHARED_EXT)
     LDFLAGS += -Wl,-install_name,$(SHARED_LIB)
+    LDFLAGS += -Wl,-dead_strip,-bind_at_load
 else ifneq (, $(shell echo $(UNAME_S) | grep -E 'MSYS|MINGW|CYGWIN'))
     SHARED_EXT = dll
     TARGET = $(BASE_NAME).$(SHARED_EXT)


### PR DESCRIPTION
From `man ld`:
```
-dead_strip
                 Remove functions and data that are unreachable by the entry point or exported symbols.
```
```
-bind_at_load
                 Sets a bit in the mach header of the resulting binary which tells dyld to bind all symbols when the binary is loaded,
                 rather than lazily.
```